### PR TITLE
feat(web2c): 2C 功能补齐 —— LLM 连接测试 + 用量仪表盘(明细+趋势图) + ark_face_svg 迁移

### DIFF
--- a/service/src/deskbot_server/web/templates/app2c/advanced.html
+++ b/service/src/deskbot_server/web/templates/app2c/advanced.html
@@ -1,6 +1,18 @@
 {% extends "base_2c.html" %}
 {% block page_title %}高级 · 小歪{% endblock %}
-{% block extra_head %}<script src="{{ url_for('static', filename='vendor/vue.global.prod.min.js') }}"></script>{% endblock %}
+{% block extra_head %}<script src="{{ url_for('static', filename='vendor/vue.global.prod.min.js') }}"></script>
+<style>
+  .usage-chart-card{border:var(--bw) solid var(--line);border-radius:var(--r);background:var(--panel);padding:12px;margin-top:12px}
+  .usage-chart{width:100%;height:200px;display:block}
+  .usage-chart .uc-axis{stroke:var(--line);stroke-width:1.5}
+  .usage-chart .uc-tick{fill:var(--dim);font-family:var(--mono);font-size:10px}
+  .usage-chart .uc-date{fill:var(--faint);font-family:var(--mono);font-size:10px}
+  .usage-legend{display:flex;flex-wrap:wrap;gap:8px 14px;margin-top:10px}
+  .usage-legend .uc-item{display:inline-flex;align-items:center;gap:5px;font-family:var(--mono);font-size:11px;color:var(--dim)}
+  .usage-legend .uc-dot{width:9px;height:9px;border-radius:50%;border:1.5px solid var(--line);flex:none}
+  .usage-chart-empty{margin-top:12px;padding:20px;text-align:center;color:var(--faint);font-family:var(--mono);font-size:11px;
+    border:var(--bw) dashed var(--line);border-radius:var(--r)}
+</style>{% endblock %}
 {% block content %}
 <div id="advancedApp">
   <div class="pagehd">
@@ -49,6 +61,48 @@
         </tbody>
       </table>
     </div>
+    <div class="blocktitle">近 14 日设备用量趋势</div>
+    <div class="usage-chart-card" v-if="deviceUsageSeries.series.length">
+      <svg class="usage-chart" viewBox="0 0 640 200" preserveAspectRatio="none" role="img">
+        <line class="uc-axis" x1="28" y1="172" x2="612" y2="172"></line>
+        <text class="uc-tick" x="24" y="32" text-anchor="end">[[ fmtBytes(deviceUsageSeries.max) ]]</text>
+        <text class="uc-tick" x="24" y="172" text-anchor="end">0</text>
+        <polyline v-for="(s, i) in deviceUsageSeries.series" :key="s.sub_id"
+                  fill="none" :stroke="chartColor(i)" stroke-width="2"
+                  stroke-linejoin="round" stroke-linecap="round"
+                  :points="svgPoints(s, deviceUsageSeries.max)"></polyline>
+        <text class="uc-date" x="28" y="190" text-anchor="start">[[ deviceUsageSeries.dates[0] ]]</text>
+        <text class="uc-date" x="612" y="190" text-anchor="end">[[ deviceUsageSeries.dates[deviceUsageSeries.dates.length-1] ]]</text>
+      </svg>
+      <div class="usage-legend">
+        <span v-for="(s, i) in deviceUsageSeries.series" :key="s.sub_id" class="uc-item">
+          <i class="uc-dot" :style="{background: chartColor(i)}"></i>[[ s.label ]]
+        </span>
+      </div>
+    </div>
+    <div class="usage-chart-empty" v-else>暂无趋势数据</div>
+
+    <div class="blocktitle">近 14 日 API Key 用量趋势</div>
+    <div class="usage-chart-card" v-if="keyUsageSeries.series.length">
+      <svg class="usage-chart" viewBox="0 0 640 200" preserveAspectRatio="none" role="img">
+        <line class="uc-axis" x1="28" y1="172" x2="612" y2="172"></line>
+        <text class="uc-tick" x="24" y="32" text-anchor="end">[[ fmtBytes(keyUsageSeries.max) ]]</text>
+        <text class="uc-tick" x="24" y="172" text-anchor="end">0</text>
+        <polyline v-for="(s, i) in keyUsageSeries.series" :key="s.sub_id"
+                  fill="none" :stroke="chartColor(i)" stroke-width="2"
+                  stroke-linejoin="round" stroke-linecap="round"
+                  :points="svgPoints(s, keyUsageSeries.max)"></polyline>
+        <text class="uc-date" x="28" y="190" text-anchor="start">[[ keyUsageSeries.dates[0] ]]</text>
+        <text class="uc-date" x="612" y="190" text-anchor="end">[[ keyUsageSeries.dates[keyUsageSeries.dates.length-1] ]]</text>
+      </svg>
+      <div class="usage-legend">
+        <span v-for="(s, i) in keyUsageSeries.series" :key="s.sub_id" class="uc-item">
+          <i class="uc-dot" :style="{background: chartColor(i)}"></i>[[ s.label ]]
+        </span>
+      </div>
+    </div>
+    <div class="usage-chart-empty" v-else>暂无趋势数据</div>
+
     <div class="blocktitle">近 14 日设备明细</div>
     <div class="adv-table-wrap">
       <table class="adv-table">
@@ -352,7 +406,57 @@ createApp({
       simText:'你好，我是小歪模拟器。', simSpkId:0, simResult:null, simAudioUrl:'',
     },
   }; },
+  computed:{
+    deviceUsageSeries(){ return this.buildUsageSeries(this.usage.device_daily_rows); },
+    keyUsageSeries(){ return this.buildUsageSeries(this.usage.key_daily_rows); },
+  },
   methods:{
+    buildUsageSeries(rows){
+      rows = Array.isArray(rows) ? rows : [];
+      const dateSet = {};
+      const groups = {};
+      const order = [];
+      for(const r of rows){
+        const date = r.date;
+        if(date != null) dateSet[date] = true;
+        const sid = r.sub_id != null ? String(r.sub_id) : '';
+        if(!groups[sid]){
+          groups[sid] = { sub_id: sid, label: r.label || r.sub_id || '未命名', byDate: {} };
+          order.push(sid);
+        }
+        groups[sid].byDate[date] = (groups[sid].byDate[date] || 0) + (Number(r.total_bytes) || 0);
+      }
+      const dates = Object.keys(dateSet).sort();
+      let max = 0;
+      const series = order.map(sid => {
+        const g = groups[sid];
+        const points = dates.map(d => {
+          const v = Number(g.byDate[d]) || 0;
+          if(v > max) max = v;
+          return v;
+        });
+        return { sub_id: g.sub_id, label: g.label, points };
+      });
+      return { dates, series, max: max || 1 };
+    },
+    svgPoints(series, max){
+      const W = 640, H = 200, pad = 28;
+      const left = pad, right = W - pad, top = pad, bottom = H - pad;
+      const plotW = right - left, plotH = bottom - top;
+      const m = (Number(max) || 0) || 1;
+      const pts = (series && series.points) || [];
+      const n = pts.length;
+      if(n === 0) return '';
+      return pts.map((v, i) => {
+        const x = n === 1 ? (left + plotW / 2) : (left + (plotW * i) / (n - 1));
+        const y = bottom - ((Number(v) || 0) / m) * plotH;
+        return x.toFixed(1) + ',' + y.toFixed(1);
+      }).join(' ');
+    },
+    chartColor(i){
+      const palette = ['#ff6700', '#2f7de1', '#1fa87a', '#c94fb0', '#e0a400', '#5b5bd6'];
+      return palette[i % palette.length];
+    },
     toggleAdvanced(key){
       this.advancedOpen[key]=!this.advancedOpen[key];
       if(key==='debug' && this.advancedOpen.debug) this.prepareDebug();

--- a/service/tests/test_app2c_pages.py
+++ b/service/tests/test_app2c_pages.py
@@ -324,6 +324,11 @@ def test_2c_expr_page_exposes_professional_design_tab(temp_db):
     assert "图片表情包生成" in html
     assert "generateImageExpression" in html
     assert "/api/face_design/generate-from-image" in html
+    assert "previewFrameIndex" in html
+    assert "generatedPreviewSvg" in html
+    assert "togglePreviewPlayback" in html
+    assert "prevGeneratedFrame" in html
+    assert "[[ generatedFrameLabel ]]" in html
     assert html.index("图片生成 / ARK SEED") < html.index("专业设计 / VISEMESYNC")
     assert "preserveMap:true" in html
     assert "/api/face_mouth_by_phoneme" in html
@@ -604,3 +609,21 @@ def test_2c_advanced_usage_includes_daily_breakdown(temp_db):
     html = client.get("/advanced").get_data(as_text=True)
     assert "近 14 日设备明细" in html
     assert "近 14 日 API Key 明细" in html
+
+
+def test_2c_advanced_usage_has_trend_charts(temp_db):
+    from deskbot_server.auth.service import create_user
+    from deskbot_server.web.app import create_app
+
+    create_user("usage-charts2c@example.com", "password1234")
+    app = create_app()
+    client = app.test_client()
+    client.post("/login", data={"email": "usage-charts2c@example.com", "password": "password1234"})
+
+    html = client.get("/advanced").get_data(as_text=True)
+    assert "近 14 日设备用量趋势" in html
+    assert "近 14 日 API Key 用量趋势" in html
+    assert "<svg" in html
+    assert "<polyline" in html
+    assert "deviceUsageSeries" in html
+    assert "keyUsageSeries" in html


### PR DESCRIPTION
## 概要
消费级 2C UI (`app2c/`) 的功能补齐。**不含**旧 `app/` 页面下线（已拆分到独立 PR，见下）。旧 `app/` 与 2C 在本 PR 中并存。

## 变更（4 提交）
- `ca6147c` ark_face_svg 迁移：图片→SVG 人脸生成 + expr 页接入（同步扁平化布局时的退避）。
- `238ed5e` **LLM 保存前连接测试**：`advanced.html` LLM 表单新增「测试连接」，配线既有 `POST /app/api/llm-models/test`。
- `076f12d` **用量 14 日明细**：`advanced_summary_get` 追加 `device_daily_rows`/`key_daily_rows`，usage 页新增按天×设备/Key 明细表。
- `8cfeec1` **用量趋势图**：usage 页新增近 14 日设备/Key 每日合计的折线图，**纯内联 SVG，无第三方依赖**（与 2C 本地 vendor 方针一致）。

## 说明
- 经逐文件核对，2C 原本已 ≈90-95% 覆盖旧 UI；本 PR 补齐真实缺口（LLM 连接测试、用量趋势可视化）。
- 每个提交经 spec 合规 + 代码质量两阶段评审。
- 逐设备 TTS 经核实为不存在的功能（全局 TTS，`voice.html` 已覆盖），无需移植。

## Test Plan（需含 ML 依赖的环境）
本地无法运行完整套件（`create_app` 依赖 mediapipe/insightface/cv2/funasr，Python 3.14 无 wheel）。已完成：全改动文件 py_compile 通过、无新增 ruff 错误、Vue `<script>` node --check 通过。请在 CI/部署环境执行：
- [ ] `cd service && uv run pytest tests/test_app2c_pages.py -v`（含新增 3 个测试：llm_form_has_test_connection / usage_includes_daily_breakdown / usage_has_trend_charts）
- [ ] `cd service && uv run ruff check src tests`
- [ ] 手动冒烟：`/advanced` 用量页显示今日/14 日/明细表/趋势折线图；LLM 表单「测试连接」可用。

## 关联
- 旧 `app/` 页面下线拆分到独立 PR（refactor/retire-app-pages），供后续单独评审/合并。
- 取代原 PR #2（已拆分关闭）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)