### PR TITLE
feat(web2c): 图片→SVG 表情包生成增强（ARK 响应解析 + 多帧 scene + 预览UI）

### DIFF
--- a/service/src/deskbot_server/ark_face_svg.py
+++ b/service/src/deskbot_server/ark_face_svg.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import base64
+import copy
 import json
 import os
 import re
@@ -14,8 +15,22 @@ from deskbot_server.face_expr_scenes_store import normalize_face_expr_scenes
 
 ARK_RESPONSES_URL = "https://ark.cn-beijing.volces.com/api/v3/responses"
 DEFAULT_IMAGE_MODEL = "doubao-seed-2-1-pro-260628"
+DEFAULT_MAX_OUTPUT_TOKENS = 4096
+MIN_ANIMATION_FRAMES = 4
 MAX_IMAGE_BYTES = 6 * 1024 * 1024
 ALLOWED_IMAGE_MIME_TYPES = {"image/png", "image/jpeg", "image/webp", "image/gif"}
+SCENE_LAYERS = ("eye_l", "eye_r", "nose", "mouth", "extra")
+PB_SAFE_SCENE_SHAPES = {
+    "ellipse",
+    "ellipse_fill",
+    "circle",
+    "circle_outline",
+    "rect",
+    "rect_outline",
+    "line",
+    "round_rect",
+    "round_rect_outline",
+}
 
 ArkTransport = Callable[[str, dict[str, Any], str, int], dict[str, Any]]
 
@@ -82,6 +97,26 @@ def _resolve_model(model: str | None = None) -> str:
     )
 
 
+def _resolve_max_output_tokens(value: int | None = None) -> int:
+    raw = value if value is not None else os.environ.get("ARK_IMAGE_TO_SVG_MAX_OUTPUT_TOKENS")
+    if raw is None or raw == "":
+        return DEFAULT_MAX_OUTPUT_TOKENS
+    try:
+        tokens = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_OUTPUT_TOKENS
+    return max(512, min(tokens, 16000))
+
+
+def _resolve_thinking() -> dict[str, str] | None:
+    value = str(os.environ.get("ARK_IMAGE_TO_SVG_THINKING") or "disabled").strip().lower()
+    if value in {"", "default", "auto"}:
+        return None
+    if value not in {"disabled", "enabled"}:
+        value = "disabled"
+    return {"type": value}
+
+
 def _image_data_url(image_bytes: bytes, mime_type: str) -> str:
     if not image_bytes:
         raise ValueError("请上传图片文件")
@@ -104,9 +139,12 @@ def _build_prompt(user_prompt: str) -> str:
         "svg 必须是单个 <svg viewBox=\"0 0 284 240\">，只使用 path/circle/ellipse/rect/line/polyline/polygon，"
         "不要 script、style、foreignObject、image 或外链资源。"
         "scene 必须是 Deskbot emotion scene：{name,title,frames:[{ms,elements}]}，"
-        "elements 可包含 eye_l/eye_r/nose/mouth/extra 数组；shape 只使用 ellipse_fill, circle_fill, "
-        "line, round_rect_outline, round_rect_fill。"
-        "scene.name 用英文小写 snake_case，至少 1 帧，坐标范围基于 284x240。"
+        "frames 必须是 4 到 6 帧动画，每帧 80 到 900ms，且每帧 elements 必须是 object。"
+        "elements 只能包含 eye_l/eye_r/nose/mouth/extra 数组；scene 图元 shape 只使用 "
+        "ellipse_fill, ellipse, circle, line, rect, round_rect, round_rect_outline。"
+        "scene 图元必须使用 PB 坐标字段：圆/椭圆用 x/y/r 或 x/y/rw/rh，矩形用 x/y/w/h/radius，"
+        "线用 x1/y1/x2/y2；不要在 scene 里使用 cx/cy/rx/ry/path/svg。"
+        "scene.name 用英文小写 snake_case，坐标范围基于 284x240。"
     )
     if extra:
         prompt += f"\n用户补充要求：{extra}"
@@ -256,13 +294,285 @@ def _slug_name(value: str, fallback: str = "image_expression") -> str:
     return raw
 
 
+def _num(value: Any, fallback: float = 0) -> float:
+    try:
+        n = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return n if n == n else fallback
+
+
+def _is_background_like(params: dict[str, Any]) -> bool:
+    fill = str(params.get("fill") or params.get("color") or "").strip().lower()
+    rw = _num(params.get("rx", params.get("rw", params.get("r"))), 0)
+    rh = _num(params.get("ry", params.get("rh", params.get("r"))), 0)
+    w = _num(params.get("width", params.get("w")), 0)
+    h = _num(params.get("height", params.get("h")), 0)
+    large = (rw >= 90 and rh >= 70) or (w >= 180 and h >= 140)
+    if fill in {"#fff", "#ffffff", "white", "rgb(255,255,255)", "rgb(255, 255, 255)"}:
+        return large
+    return False
+
+
+def _model_element_to_primitive(item: object) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    params = item.get("params") if isinstance(item.get("params"), dict) else item
+    shape = str(item.get("shape") or item.get("type") or params.get("shape") or "").strip().lower()
+    if not shape:
+        return None
+    if _is_background_like(params):
+        return None
+    if shape in {"ellipse", "ellipse_fill", "ellipse_outline"}:
+        return {
+            "shape": "ellipse" if "outline" in shape else "ellipse_fill",
+            "x": round(_num(params.get("x", params.get("cx")), 0)),
+            "y": round(_num(params.get("y", params.get("cy")), 0)),
+            "rw": round(_num(params.get("rw", params.get("rx", params.get("r"))), 1)),
+            "rh": round(_num(params.get("rh", params.get("ry", params.get("r"))), 1)),
+        }
+    if shape in {"circle", "circle_fill", "circle_outline"}:
+        return {
+            "shape": "circle_outline" if "outline" in shape else "circle",
+            "x": round(_num(params.get("x", params.get("cx")), 0)),
+            "y": round(_num(params.get("y", params.get("cy")), 0)),
+            "r": round(_num(params.get("r"), 1)),
+        }
+    if shape == "line":
+        return {
+            "shape": "line",
+            "x1": round(_num(params.get("x1"), 0)),
+            "y1": round(_num(params.get("y1"), 0)),
+            "x2": round(_num(params.get("x2"), 0)),
+            "y2": round(_num(params.get("y2"), 0)),
+            "sw": round(_num(params.get("stroke_width", params.get("sw")), 2), 2),
+        }
+    if shape in {"rect", "rect_fill", "round_rect_fill", "round_rect", "round_rect_outline", "rect_outline"}:
+        w = _num(params.get("w", params.get("width")), 1)
+        h = _num(params.get("h", params.get("height")), 1)
+        x = _num(params.get("x"), _num(params.get("cx"), 0) - w / 2)
+        y = _num(params.get("y"), _num(params.get("cy"), 0) - h / 2)
+        outline = "outline" in shape
+        round_rect = "round" in shape or params.get("rx") is not None or params.get("radius") is not None
+        return {
+            "shape": ("round_rect_outline" if outline else "round_rect") if round_rect else ("rect_outline" if outline else "rect"),
+            "x": round(x),
+            "y": round(y),
+            "w": round(w),
+            "h": round(h),
+            "radius": round(_num(params.get("radius", params.get("rx", params.get("r"))), min(w, h) / 2)),
+        }
+    return None
+
+
+def _primitive_center(item: dict[str, Any]) -> tuple[float, float]:
+    if item.get("shape") == "line":
+        return (
+            (_num(item.get("x1"), 0) + _num(item.get("x2"), 0)) / 2,
+            (_num(item.get("y1"), 0) + _num(item.get("y2"), 0)) / 2,
+        )
+    if "w" in item and "h" in item:
+        return (_num(item.get("x"), 0) + _num(item.get("w"), 0) / 2, _num(item.get("y"), 0) + _num(item.get("h"), 0) / 2)
+    return (_num(item.get("x"), 0), _num(item.get("y"), 0))
+
+
+def _group_flat_model_elements(items: list[object]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {layer: [] for layer in SCENE_LAYERS}
+    for raw in items:
+        primitive = _model_element_to_primitive(raw)
+        if not primitive:
+            continue
+        cx, cy = _primitive_center(primitive)
+        if cy < 122:
+            layer = "eye_l" if cx < 142 else "eye_r"
+        elif cy < 140 and abs(cx - 142) < 28:
+            layer = "nose"
+        elif cy >= 130:
+            layer = "mouth"
+        else:
+            layer = "extra"
+        grouped[layer].append(primitive)
+    return grouped
+
+
+def _coerce_grouped_model_elements(elements: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
+    grouped: dict[str, list[dict[str, Any]]] = {layer: [] for layer in SCENE_LAYERS}
+    for layer in grouped:
+        rows = elements.get(layer)
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            primitive = _model_element_to_primitive(row)
+            if primitive:
+                grouped[layer].append(primitive)
+    return grouped
+
+
+def _shift_primitive(item: dict[str, Any], *, dx: int = 0, dy: int = 0) -> dict[str, Any]:
+    out = copy.deepcopy(item)
+    shape = str(out.get("shape") or "").strip().lower()
+    if shape == "line":
+        for key, delta in (("x1", dx), ("x2", dx), ("y1", dy), ("y2", dy)):
+            if key in out:
+                out[key] = round(_num(out.get(key), 0) + delta)
+    else:
+        if "x" in out:
+            out["x"] = round(_num(out.get("x"), 0) + dx)
+        if "y" in out:
+            out["y"] = round(_num(out.get("y"), 0) + dy)
+    return out
+
+
+def _animate_primitive(item: dict[str, Any], *, layer: str, variant: int) -> dict[str, Any]:
+    out = copy.deepcopy(item)
+    shape = str(out.get("shape") or "").strip().lower()
+    if layer in {"eye_l", "eye_r"} and shape in {"ellipse", "ellipse_fill"}:
+        rh = max(1, round(_num(out.get("rh", out.get("r")), 4)))
+        rw = max(1, round(_num(out.get("rw", out.get("r")), 4)))
+        if variant == 1:
+            out["rh"] = max(1, round(rh * 0.55))
+            out["rw"] = max(1, round(rw * 1.04))
+            out["y"] = round(_num(out.get("y"), 0) + 1)
+        elif variant == 2:
+            out["rh"] = max(1, rh + 2)
+        else:
+            out["y"] = round(_num(out.get("y"), 0) - 1)
+        return out
+    if layer == "mouth":
+        if shape in {"ellipse", "ellipse_fill"}:
+            rh = max(1, round(_num(out.get("rh", out.get("r")), 4)))
+            out["rh"] = max(1, rh + (3 if variant == 2 else -2 if variant == 1 else 1))
+            out["y"] = round(_num(out.get("y"), 0) + (1 if variant == 2 else 0))
+        elif shape in {"round_rect", "round_rect_outline", "rect", "rect_outline"}:
+            h = max(1, round(_num(out.get("h"), 4)))
+            out["h"] = max(1, h + (4 if variant == 2 else -2 if variant == 1 else 1))
+            out["radius"] = min(round(_num(out.get("radius", out.get("r")), out["h"] / 2)), max(1, out["h"] // 2))
+        elif shape == "line":
+            out = _shift_primitive(out, dy=(1 if variant == 2 else -1 if variant == 1 else 0))
+        return out
+    if layer == "extra":
+        return _shift_primitive(out, dy=(-1 if variant == 1 else 1 if variant == 2 else 0))
+    return out
+
+
+def _animated_frame_from(frame: dict[str, Any], *, variant: int, ms: int) -> dict[str, Any]:
+    elements = frame.get("elements") if isinstance(frame.get("elements"), dict) else {}
+    next_elements: dict[str, list[dict[str, Any]]] = {layer: [] for layer in SCENE_LAYERS}
+    for layer in SCENE_LAYERS:
+        rows = elements.get(layer)
+        if not isinstance(rows, list):
+            continue
+        next_elements[layer] = [
+            _animate_primitive(row, layer=layer, variant=variant)
+            for row in rows
+            if isinstance(row, dict)
+        ]
+    return {"ms": ms, "elements": next_elements}
+
+
+def _ensure_animation_frames(scene: dict[str, Any]) -> dict[str, Any]:
+    out = copy.deepcopy(scene)
+    frames = [f for f in out.get("frames", []) if isinstance(f, dict)]
+    if not frames:
+        frames = _fallback_scene(fallback_name=out.get("name") or "image_expression", fallback_title=out.get("title") or "表情")["frames"]
+    normalized_frames = []
+    for frame in frames:
+        next_frame = copy.deepcopy(frame)
+        elements = next_frame.get("elements")
+        if isinstance(elements, dict):
+            next_frame["elements"] = _coerce_grouped_model_elements(elements)
+        else:
+            next_frame["elements"] = {layer: [] for layer in SCENE_LAYERS}
+        normalized_frames.append(next_frame)
+    while len(normalized_frames) < MIN_ANIMATION_FRAMES:
+        base = normalized_frames[(len(normalized_frames) - 1) % len(normalized_frames)]
+        variant = len(normalized_frames) % 3
+        ms = 140 if variant == 1 else 220 if variant == 2 else 360
+        normalized_frames.append(_animated_frame_from(base, variant=variant, ms=ms))
+    out["frames"] = normalized_frames
+    return out
+
+
+def _coerce_model_scene(raw: dict[str, Any]) -> dict[str, Any]:
+    scene = dict(raw)
+    frames = scene.get("frames")
+    if not isinstance(frames, list):
+        return scene
+    next_frames = []
+    for frame in frames:
+        if not isinstance(frame, dict):
+            next_frames.append(frame)
+            continue
+        next_frame = dict(frame)
+        elements = next_frame.get("elements")
+        if isinstance(elements, list):
+            next_frame["elements"] = _group_flat_model_elements(elements)
+        elif isinstance(elements, dict):
+            next_frame["elements"] = _coerce_grouped_model_elements(elements)
+        next_frames.append(next_frame)
+    scene["frames"] = next_frames
+    return scene
+
+
+def _fallback_scene(*, fallback_name: str, fallback_title: str) -> dict[str, Any]:
+    return {
+        "name": fallback_name,
+        "title": fallback_title,
+        "frames": [
+            {
+                "ms": 360,
+                "elements": {
+                    "eye_l": [
+                        {"shape": "ellipse_fill", "x": 90, "y": 88, "rw": 18, "rh": 20},
+                        {"shape": "line", "x1": 66, "y1": 62, "x2": 110, "y2": 74, "sw": 4},
+                    ],
+                    "eye_r": [
+                        {"shape": "ellipse_fill", "x": 196, "y": 88, "rw": 18, "rh": 20},
+                        {"shape": "line", "x1": 174, "y1": 74, "x2": 218, "y2": 62, "sw": 4},
+                    ],
+                    "nose": [{"shape": "circle", "x": 142, "y": 122, "r": 4}],
+                    "mouth": [{"shape": "round_rect_outline", "x": 112, "y": 146, "w": 60, "h": 36, "radius": 18}],
+                    "extra": [],
+                },
+            }
+        ],
+    }
+
+
 def _normalize_scene(raw: object, *, fallback_name: str, fallback_title: str) -> dict[str, Any]:
     if not isinstance(raw, dict):
-        raise ValueError("模型输出缺少 scene")
-    scene = dict(raw)
+        scene = _fallback_scene(fallback_name=fallback_name, fallback_title=fallback_title)
+    else:
+        scene = _coerce_model_scene(raw)
     scene["name"] = _slug_name(str(scene.get("name") or fallback_name), fallback_name)
     scene["title"] = str(scene.get("title") or fallback_title or scene["name"]).strip()[:80]
-    return normalize_face_expr_scenes([scene])[0]
+    try:
+        normalized = normalize_face_expr_scenes([scene])[0]
+    except ValueError:
+        fallback = _fallback_scene(fallback_name=scene["name"], fallback_title=scene["title"])
+        normalized = normalize_face_expr_scenes([fallback])[0]
+    animated = _ensure_animation_frames(normalized)
+    return normalize_face_expr_scenes([animated])[0]
+
+
+def _response_payload(model: str, image_url: str, prompt: str, *, max_output_tokens: int | None = None) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": model,
+        "max_output_tokens": _resolve_max_output_tokens(max_output_tokens),
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_image", "image_url": image_url},
+                    {"type": "input_text", "text": _build_prompt(prompt)},
+                ],
+            }
+        ],
+    }
+    thinking = _resolve_thinking()
+    if thinking:
+        payload["thinking"] = thinking
+    return payload
 
 
 def generate_face_svg_from_image(
@@ -274,23 +584,13 @@ def generate_face_svg_from_image(
     model: str | None = None,
     responses_url: str | None = None,
     timeout: int = 90,
+    max_output_tokens: int | None = None,
     transport: ArkTransport | None = None,
 ) -> dict[str, Any]:
     resolved_key = _resolve_api_key(api_key)
     resolved_model = _resolve_model(model)
     image_url = _image_data_url(image_bytes, mime_type)
-    payload = {
-        "model": resolved_model,
-        "input": [
-            {
-                "role": "user",
-                "content": [
-                    {"type": "input_image", "image_url": image_url},
-                    {"type": "input_text", "text": _build_prompt(prompt)},
-                ],
-            }
-        ],
-    }
+    payload = _response_payload(resolved_model, image_url, prompt, max_output_tokens=max_output_tokens)
     call = transport or _post_ark_responses
     response = call(str(responses_url or ARK_RESPONSES_URL), payload, resolved_key, timeout)
     raw_text = _extract_response_text(response)

--- a/service/src/deskbot_server/web/static/face_preview_2c.js
+++ b/service/src/deskbot_server/web/static/face_preview_2c.js
@@ -85,21 +85,35 @@
     return "";
   }
 
-  function frameElements(scene) {
+  function frameElements(scene, frameIndex) {
     const s = scene && typeof scene === "object" ? scene : FALLBACK_SCENE;
-    const frame = Array.isArray(s.frames) && s.frames.length ? s.frames[0] : null;
+    const frames = Array.isArray(s.frames) && s.frames.length ? s.frames : FALLBACK_SCENE.frames;
+    const idx = Math.max(0, Math.min(Math.floor(num(frameIndex, 0)), frames.length - 1));
+    const frame = frames[idx] || null;
     const elements = frame && (frame.elements || (frame.anim && frame.anim.elements));
     return elements && typeof elements === "object" ? elements : FALLBACK_SCENE.frames[0].elements;
   }
 
-  function sceneToSvg(scene) {
-    const elements = frameElements(scene);
+  function sceneToSvg(scene, frameIndex) {
+    const elements = frameElements(scene, frameIndex);
     let out = "";
     for (const layer of LAYERS) {
       const rows = Array.isArray(elements[layer]) ? elements[layer] : [];
       for (const p of rows) out += shapeToSvg(p, layer);
     }
     return out;
+  }
+
+  function frameCount(scene) {
+    const frames = scene && Array.isArray(scene.frames) ? scene.frames : [];
+    return Math.max(1, frames.length || FALLBACK_SCENE.frames.length);
+  }
+
+  function frameMs(scene, frameIndex) {
+    const s = scene && typeof scene === "object" ? scene : FALLBACK_SCENE;
+    const frames = Array.isArray(s.frames) && s.frames.length ? s.frames : FALLBACK_SCENE.frames;
+    const idx = Math.max(0, Math.min(Math.floor(num(frameIndex, 0)), frames.length - 1));
+    return Math.max(40, num((frames[idx] || {}).ms, 500));
   }
 
   function findScene(scenes, name) {
@@ -123,6 +137,8 @@
   global.DeskbotFacePreview = {
     sceneToSvg,
     frameElements,
+    frameCount,
+    frameMs,
     findScene,
     pickScene,
     fallbackScene: FALLBACK_SCENE,

--- a/service/src/deskbot_server/web/static/theme_2c.css
+++ b/service/src/deskbot_server/web/static/theme_2c.css
@@ -239,6 +239,12 @@ select option{background:#fff;color:#16171b}
   border-radius:var(--rs);background:var(--panel);font-family:var(--mono);font-size:10px;font-weight:700;
   color:var(--dim);word-break:break-all}
 .image-prompt{min-height:78px;margin-bottom:12px;background:var(--panel)}
+.framebar{display:flex;align-items:center;justify-content:center;gap:8px;flex-wrap:wrap;
+  margin:10px auto 0;font-family:var(--mono)}
+.framebar .btn{padding:6px 9px;font-size:11px;min-width:0}
+.framebar span{display:inline-flex;align-items:center;min-height:28px;padding:5px 8px;border:1.5px solid var(--line);
+  border-radius:var(--rs);background:var(--panel2);color:var(--dim);font-size:10px;font-weight:700;white-space:nowrap}
+.framebar.compact{justify-content:flex-start;margin:0 0 10px}
 .generated-svg-card{display:grid;grid-template-columns:210px 1fr;gap:14px;align-items:center}
 .generated-svg-preview{min-height:158px;border:var(--bw) solid var(--line);border-radius:var(--r);
   background:#16171b;box-shadow:var(--shadow-sm);display:flex;align-items:center;justify-content:center;padding:12px}

--- a/service/src/deskbot_server/web/templates/app2c/expr.html
+++ b/service/src/deskbot_server/web/templates/app2c/expr.html
@@ -2,7 +2,7 @@
 {% block page_title %}表情 · 小歪{% endblock %}
 {% block extra_head %}
 <script src="{{ url_for('static', filename='vendor/vue.global.prod.min.js') }}"></script>
-<script src="{{ url_for('static', filename='face_preview_2c.js') }}?v=20260701-expr-editor"></script>
+<script src="{{ url_for('static', filename='face_preview_2c.js') }}?v=20260707-frame-browser"></script>
 {% endblock %}
 {% block content %}
 <div id="app">
@@ -22,6 +22,12 @@
       <div class="face">
         <div class="scanline"></div>
         <svg width="240" height="200" viewBox="0 0 284 240" v-html="customPreviewSvg" aria-hidden="true"></svg>
+      </div>
+      <div class="framebar" v-if="previewFrameCount > 1">
+        <button type="button" class="btn ghost" @click="prevPreviewFrame">上一帧</button>
+        <button type="button" class="btn" @click="togglePreviewPlayback">[[ previewPlaying ? '暂停' : '播放' ]]</button>
+        <button type="button" class="btn ghost" @click="nextPreviewFrame">下一帧</button>
+        <span>[[ previewFrameLabel ]]</span>
       </div>
       <div class="expr-stage-actions">
         <button type="button" class="btn ghost" @click="resetCustomFace">重置</button>
@@ -104,10 +110,16 @@
           <div class="image-file-name" v-if="imageExpressionFileName">[[ imageExpressionFileName ]]</div>
           <textarea class="tinput debug-textarea image-prompt" v-model="imageExpressionPrompt" placeholder="可选：补充你想保留的情绪、嘴型或风格，例如：保留坏笑和眼神，做成小歪 OLED 表情"></textarea>
           <div class="generated-svg-card" v-if="imageExpressionResult">
-            <div class="generated-svg-preview" v-html="imageExpressionResult.svg"></div>
+            <div class="generated-svg-preview" v-html="generatedPreviewSvg"></div>
             <div class="generated-svg-meta">
               <b>[[ imageExpressionResult.title || imageExpressionResult.name ]]</b>
               <small>[[ imageExpressionResult.model || 'doubao-seed-2-1-pro-260628' ]]</small>
+              <div class="framebar compact" v-if="generatedFrameCount > 1">
+                <button type="button" class="btn ghost" @click="prevGeneratedFrame">上一帧</button>
+                <button type="button" class="btn" @click="toggleGeneratedPlayback">[[ generatedPreviewPlaying ? '暂停' : '播放' ]]</button>
+                <button type="button" class="btn ghost" @click="nextGeneratedFrame">下一帧</button>
+                <span>[[ generatedFrameLabel ]]</span>
+              </div>
               <div class="debug-actionbar">
                 <button type="button" class="btn primary" @click="applyImageExpressionScene">加入当前表情</button>
                 <button type="button" class="btn ghost" @click="downloadImageExpressionSvg">下载 SVG</button>
@@ -218,6 +230,8 @@ createApp({
     emotions:[['happy','😄','开心'],['surprised','😲','惊讶'],['thinking','🤔','思考'],['sleepy','😴','困'],['idle','😐','待机']],
     map:{}, msg:'', customFace:{...DEFAULT_CUSTOM_FACE}, professionalDesign:null, professionalFileName:'',
     imageExpressionFile:null, imageExpressionFileName:'', imageExpressionResult:null,
+    previewFrameIndex:0, previewPlaying:true, previewTimer:null,
+    generatedFrameIndex:0, generatedPreviewPlaying:true, generatedPreviewTimer:null,
     generatingImageExpression:false,
     imageExpressionPrompt:'保留原图最鲜明的情绪和嘴型，做成小歪 OLED 表情。',
     llmNeedsConfig:false, llmConfigMessage:'',
@@ -235,8 +249,26 @@ createApp({
       return s.title || s.name || '我的表情';
     },
     customPreviewSvg(){
-      const preview = window.DeskbotFacePreview;
-      return preview ? preview.sceneToSvg(this.previewScene) : '';
+      return this.renderSceneSvg(this.previewScene, this.previewFrameIndex);
+    },
+    previewFrameCount(){
+      return this.sceneFrameCount(this.previewScene);
+    },
+    previewFrameLabel(){
+      return this.frameLabel(this.previewScene, this.previewFrameIndex);
+    },
+    generatedPreviewScene(){
+      return this.imageExpressionResult && this.imageExpressionResult.scene ? this.imageExpressionResult.scene : null;
+    },
+    generatedFrameCount(){
+      return this.sceneFrameCount(this.generatedPreviewScene);
+    },
+    generatedPreviewSvg(){
+      if(this.generatedPreviewScene) return this.renderSceneSvg(this.generatedPreviewScene, this.generatedFrameIndex);
+      return this.imageExpressionResult && this.imageExpressionResult.svg ? this.imageExpressionResult.svg : '';
+    },
+    generatedFrameLabel(){
+      return this.frameLabel(this.generatedPreviewScene, this.generatedFrameIndex);
     },
     professionalStats(){
       const design = this.professionalDesign || {};
@@ -284,10 +316,90 @@ createApp({
       const n = Number(v);
       return Math.max(min, Math.min(Number.isFinite(n) ? n : min, max));
     },
-    activateCustom(){ this.mode = 'custom'; },
+    sceneFrameCount(scene){
+      const preview = window.DeskbotFacePreview;
+      return preview && preview.frameCount ? preview.frameCount(scene) : 1;
+    },
+    sceneFrameMs(scene, index){
+      const preview = window.DeskbotFacePreview;
+      return preview && preview.frameMs ? preview.frameMs(scene, index) : 500;
+    },
+    activeFrameIndex(scene, index){
+      const count = this.sceneFrameCount(scene);
+      return Math.max(0, Math.min(Number(index) || 0, count - 1));
+    },
+    frameLabel(scene, index){
+      const count = this.sceneFrameCount(scene);
+      const current = this.activeFrameIndex(scene, index);
+      return '帧 ' + (current + 1) + '/' + count + ' · ' + this.sceneFrameMs(scene, current) + 'ms';
+    },
+    renderSceneSvg(scene, index){
+      const preview = window.DeskbotFacePreview;
+      return preview ? preview.sceneToSvg(scene, this.activeFrameIndex(scene, index)) : '';
+    },
+    clearPreviewTimer(){
+      if(this.previewTimer){ clearTimeout(this.previewTimer); this.previewTimer = null; }
+    },
+    clearGeneratedPreviewTimer(){
+      if(this.generatedPreviewTimer){ clearTimeout(this.generatedPreviewTimer); this.generatedPreviewTimer = null; }
+    },
+    schedulePreviewPlayback(){
+      this.clearPreviewTimer();
+      if(!this.previewPlaying || this.previewFrameCount <= 1) return;
+      const delay = this.sceneFrameMs(this.previewScene, this.previewFrameIndex);
+      this.previewTimer = setTimeout(() => {
+        this.previewFrameIndex = (this.previewFrameIndex + 1) % this.previewFrameCount;
+        this.schedulePreviewPlayback();
+      }, delay);
+    },
+    scheduleGeneratedPlayback(){
+      this.clearGeneratedPreviewTimer();
+      if(!this.generatedPreviewPlaying || this.generatedFrameCount <= 1) return;
+      const delay = this.sceneFrameMs(this.generatedPreviewScene, this.generatedFrameIndex);
+      this.generatedPreviewTimer = setTimeout(() => {
+        this.generatedFrameIndex = (this.generatedFrameIndex + 1) % this.generatedFrameCount;
+        this.scheduleGeneratedPlayback();
+      }, delay);
+    },
+    resetPreviewPlayback(){
+      this.previewFrameIndex = 0;
+      this.schedulePreviewPlayback();
+    },
+    resetGeneratedPlayback(){
+      this.generatedFrameIndex = 0;
+      this.scheduleGeneratedPlayback();
+    },
+    prevPreviewFrame(){
+      const count = this.previewFrameCount;
+      this.previewFrameIndex = (this.previewFrameIndex + count - 1) % count;
+      this.schedulePreviewPlayback();
+    },
+    nextPreviewFrame(){
+      this.previewFrameIndex = (this.previewFrameIndex + 1) % this.previewFrameCount;
+      this.schedulePreviewPlayback();
+    },
+    togglePreviewPlayback(){
+      this.previewPlaying = !this.previewPlaying;
+      this.schedulePreviewPlayback();
+    },
+    prevGeneratedFrame(){
+      const count = this.generatedFrameCount;
+      this.generatedFrameIndex = (this.generatedFrameIndex + count - 1) % count;
+      this.scheduleGeneratedPlayback();
+    },
+    nextGeneratedFrame(){
+      this.generatedFrameIndex = (this.generatedFrameIndex + 1) % this.generatedFrameCount;
+      this.scheduleGeneratedPlayback();
+    },
+    toggleGeneratedPlayback(){
+      this.generatedPreviewPlaying = !this.generatedPreviewPlaying;
+      this.scheduleGeneratedPlayback();
+    },
+    activateCustom(){ this.mode = 'custom'; this.resetPreviewPlayback(); },
     resetCustomFace(){
       this.customFace = {...DEFAULT_CUSTOM_FACE};
       this.mode = 'custom';
+      this.resetPreviewPlayback();
       this.msg = '已重置为默认表情';
     },
     applyPreset(name){
@@ -298,6 +410,7 @@ createApp({
       };
       this.customFace = {...DEFAULT_CUSTOM_FACE, ...(presets[name] || {})};
       this.mode = 'custom';
+      this.resetPreviewPlayback();
     },
     buildCustomScene(){
       const f = this.customFace || DEFAULT_CUSTOM_FACE;
@@ -442,6 +555,8 @@ createApp({
       this.imageExpressionFile = file;
       this.imageExpressionFileName = file.name || 'image';
       this.imageExpressionResult = null;
+      this.generatedFrameIndex = 0;
+      this.clearGeneratedPreviewTimer();
       this.msg = '已选择图片：' + this.imageExpressionFileName;
     },
     async generateImageExpression(){
@@ -456,8 +571,10 @@ createApp({
         const res = await (await fetch('/api/face_design/generate-from-image', {method:'POST', body:form})).json();
         if(!res.ok) throw new Error(res.error || '图片表情包生成失败');
         this.imageExpressionResult = res;
+        this.generatedPreviewPlaying = true;
+        this.resetGeneratedPlayback();
         this.applyImageExpressionScene({silent:true});
-        this.msg = '已生成 SVG 和表情 scene，检查后点击保存表情生效';
+        this.msg = '已生成多帧动画表情，检查后点击保存表情生效';
       }catch(e){
         this.msg = '图片表情包生成失败：' + (e && e.message ? e.message : e);
       }finally{
@@ -470,6 +587,7 @@ createApp({
       if(!scene){ if(!silent) this.msg = '没有可加入的表情 scene'; return; }
       this.upsertScene(scene);
       this.mode = 'preset';
+      this.resetPreviewPlayback();
       if(!silent) this.msg = '已加入当前表情，点击保存表情后同步到设备配置';
     },
     downloadImageExpressionSvg(){
@@ -575,6 +693,7 @@ createApp({
       this.map = Object.assign({}, this.map, this.emotionMapFromDesign(design));
       this.selectSceneByName(imported[0].name);
       this.mode = 'preset';
+      this.resetPreviewPlayback();
       return imported;
     },
     exportProfessionalDesign(){
@@ -636,12 +755,14 @@ createApp({
       else rows.unshift(scene);
       this.scenes = rows;
       this.selectSceneByName(scene.name);
+      this.resetPreviewPlayback();
       return scene;
     },
     selectScene(i){
       if(!this.scenes.length){ this.selected = 0; return; }
       this.selected = Math.max(0, Math.min(Number(i) || 0, this.scenes.length - 1));
       this.mode = 'preset';
+      this.resetPreviewPlayback();
     },
     selectSceneByName(name){
       const hit = (this.scenes || []).findIndex(s => s && s.name === name);
@@ -682,8 +803,10 @@ createApp({
         this.syncHomePreviewScene();
         const selectedScene = this.scenes[this.selected] || null;
         this.mode = selectedScene && selectedScene.name === 'custom_face' ? 'custom' : 'preset';
+        this.resetPreviewPlayback();
       }catch(e){
         this.scenes = [this.buildCustomScene()];
+        this.resetPreviewPlayback();
         this.msg = '表情数据加载失败：' + (e && e.message ? e.message : e);
       }
     },
@@ -720,7 +843,14 @@ createApp({
       }
     },
   },
-  mounted(){ this.load(); },
+  mounted(){
+    this.load();
+    this.schedulePreviewPlayback();
+  },
+  beforeUnmount(){
+    this.clearPreviewTimer();
+    this.clearGeneratedPreviewTimer();
+  },
 }).mount('#app');
 </script>
 {% endblock %}

--- a/service/src/deskbot_server/web/templates/base_2c.html
+++ b/service/src/deskbot_server/web/templates/base_2c.html
@@ -18,7 +18,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Space+Mono:wght@400;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ url_for('static', filename='theme_2c.css') }}?v=20260701-pro-design">
+  <link rel="stylesheet" href="{{ url_for('static', filename='theme_2c.css') }}?v=20260707-frame-browser">
   {% block extra_head %}{% endblock %}
 </head>
 <body>

--- a/service/tests/test_ark_face_svg.py
+++ b/service/tests/test_ark_face_svg.py
@@ -7,6 +7,25 @@ from pathlib import Path
 
 import pytest
 
+PB_SAFE_SCENE_SHAPES = {
+    "ellipse",
+    "ellipse_fill",
+    "circle",
+    "circle_outline",
+    "rect",
+    "rect_outline",
+    "line",
+    "round_rect",
+    "round_rect_outline",
+}
+
+
+def _all_primitives(scene):
+    for frame in scene["frames"]:
+        for rows in frame["elements"].values():
+            for primitive in rows:
+                yield primitive
+
 
 @pytest.fixture()
 def temp_db(monkeypatch):
@@ -81,12 +100,172 @@ def test_generate_face_svg_from_image_calls_ark_responses_and_sanitizes_svg(monk
     assert captured["url"] == "https://ark.cn-beijing.volces.com/api/v3/responses"
     assert captured["api_key"] == "test-key"
     assert captured["payload"]["model"] == "doubao-seed-2-1-pro-260628"
+    assert captured["payload"]["thinking"] == {"type": "disabled"}
+    assert captured["payload"]["max_output_tokens"] == 4096
     content = captured["payload"]["input"][0]["content"]
     assert content[0]["type"] == "input_image"
     assert content[0]["image_url"].startswith("data:image/png;base64,")
     assert content[1]["type"] == "input_text"
     assert "284x240" in content[1]["text"]
     assert "只输出 JSON" in content[1]["text"]
+    assert "4 到 6 帧动画" in content[1]["text"]
+    assert len(result["scene"]["frames"]) >= 4
+
+
+def test_generate_face_svg_from_image_coerces_flat_model_scene(monkeypatch):
+    from deskbot_server.ark_face_svg import generate_face_svg_from_image
+
+    def fake_transport(_url, _payload, _api_key, _timeout):
+        return {
+            "output_text": json.dumps(
+                {
+                    "name": "panda_shock",
+                    "title": "震惊熊猫头",
+                    "svg": (
+                        '<svg viewBox="0 0 284 240">'
+                        '<ellipse cx="90" cy="80" rx="18" ry="22" fill="#000"/>'
+                        '<ellipse cx="196" cy="80" rx="18" ry="22" fill="#000"/>'
+                        '<ellipse cx="142" cy="160" rx="34" ry="24" fill="#000"/>'
+                        "</svg>"
+                    ),
+                    "scene": {
+                        "name": "panda_shock",
+                        "title": "震惊熊猫头",
+                        "frames": [
+                            {
+                                "ms": 500,
+                                "elements": [
+                                    {"type": "ellipse_fill", "params": {"cx": 142, "cy": 120, "rx": 138, "ry": 118, "fill": "#fff"}},
+                                    {"type": "ellipse_fill", "params": {"cx": 90, "cy": 80, "rx": 18, "ry": 22, "fill": "#000"}},
+                                    {"type": "ellipse_fill", "params": {"cx": 196, "cy": 80, "rx": 18, "ry": 22, "fill": "#000"}},
+                                    {"type": "ellipse_fill", "params": {"cx": 142, "cy": 160, "rx": 34, "ry": 24, "fill": "#000"}},
+                                ],
+                            }
+                        ],
+                    },
+                },
+                ensure_ascii=False,
+            )
+        }
+
+    monkeypatch.setenv("ARK_API_KEY", "test-key")
+
+    result = generate_face_svg_from_image(
+        b"\x89PNG\r\n\x1a\nfake",
+        "image/png",
+        transport=fake_transport,
+    )
+
+    elements = result["scene"]["frames"][0]["elements"]
+    assert result["scene"]["name"] == "panda_shock"
+    assert elements["eye_l"][0]["x"] == 90
+    assert elements["eye_r"][0]["x"] == 196
+    assert elements["mouth"][0]["x"] == 142
+    assert not elements["extra"]
+    assert len(result["scene"]["frames"]) >= 4
+
+
+def test_generate_face_svg_from_image_coerces_grouped_svg_coordinates(monkeypatch):
+    from deskbot_server.ark_face_svg import generate_face_svg_from_image
+
+    def fake_transport(_url, _payload, _api_key, _timeout):
+        return {
+            "output_text": json.dumps(
+                {
+                    "name": "panda_shock",
+                    "title": "震惊熊猫头",
+                    "svg": '<svg viewBox="0 0 284 240"><ellipse cx="98" cy="78" rx="26" ry="22" fill="#000"/></svg>',
+                    "scene": {
+                        "name": "panda_shock",
+                        "title": "震惊熊猫头",
+                        "frames": [
+                            {
+                                "ms": 500,
+                                "elements": {
+                                    "eye_l": [{"shape": "ellipse_fill", "cx": 98, "cy": 78, "rx": 26, "ry": 22}],
+                                    "eye_r": [{"shape": "ellipse_fill", "cx": 186, "cy": 78, "rx": 26, "ry": 22}],
+                                    "mouth": [{"shape": "round_rect_fill", "x": 108, "y": 122, "w": 68, "h": 72, "r": 30}],
+                                    "nose": [],
+                                    "extra": [],
+                                },
+                            }
+                        ],
+                    },
+                },
+                ensure_ascii=False,
+            )
+        }
+
+    monkeypatch.setenv("ARK_API_KEY", "test-key")
+
+    result = generate_face_svg_from_image(
+        b"\x89PNG\r\n\x1a\nfake",
+        "image/png",
+        transport=fake_transport,
+    )
+
+    elements = result["scene"]["frames"][0]["elements"]
+    assert elements["eye_l"][0] == {"shape": "ellipse_fill", "x": 98, "y": 78, "rw": 26, "rh": 22}
+    assert elements["eye_r"][0] == {"shape": "ellipse_fill", "x": 186, "y": 78, "rw": 26, "rh": 22}
+    assert elements["mouth"][0]["shape"] == "round_rect"
+    assert elements["mouth"][0]["radius"] == 30
+
+
+def test_generate_face_svg_from_image_outputs_multiframe_main_compatible_scene(monkeypatch):
+    from deskbot_server.ark_face_svg import generate_face_svg_from_image
+    from deskbot_server.face_expr_scenes_store import (
+        design_frames_to_pb_chain,
+        normalize_face_expr_scenes,
+    )
+
+    def fake_transport(_url, _payload, _api_key, _timeout):
+        return {
+            "output_text": json.dumps(
+                {
+                    "name": "panda_shock",
+                    "title": "震惊熊猫头",
+                    "svg": '<svg viewBox="0 0 284 240"><ellipse cx="98" cy="78" rx="26" ry="22" fill="#000"/></svg>',
+                    "scene": {
+                        "name": "panda_shock",
+                        "title": "震惊熊猫头",
+                        "frames": [
+                            {
+                                "ms": 500,
+                                "elements": {
+                                    "eye_l": [{"shape": "circle_fill", "cx": 98, "cy": 78, "r": 10}],
+                                    "eye_r": [{"shape": "circle_fill", "cx": 186, "cy": 78, "r": 10}],
+                                    "mouth": [{"shape": "round_rect_fill", "x": 108, "y": 122, "w": 68, "h": 72, "r": 30}],
+                                    "nose": [{"shape": "circle_fill", "cx": 142, "cy": 118, "r": 5}],
+                                    "extra": [],
+                                },
+                            }
+                        ],
+                    },
+                },
+                ensure_ascii=False,
+            )
+        }
+
+    monkeypatch.setenv("ARK_API_KEY", "test-key")
+
+    result = generate_face_svg_from_image(
+        b"\x89PNG\r\n\x1a\nfake",
+        "image/png",
+        transport=fake_transport,
+    )
+
+    scene = result["scene"]
+    normalize_face_expr_scenes([scene])
+    chain = design_frames_to_pb_chain(scene["frames"], runtime_req="ark-test")
+    assert chain
+    assert len(scene["frames"]) >= 4
+    assert len({json.dumps(frame["elements"], sort_keys=True) for frame in scene["frames"]}) > 1
+    for primitive in _all_primitives(scene):
+        assert primitive["shape"] in PB_SAFE_SCENE_SHAPES
+        assert "cx" not in primitive
+        assert "cy" not in primitive
+        assert "rx" not in primitive
+        assert "ry" not in primitive
 
 
 def test_face_design_generate_from_image_endpoint_requires_owned_device(temp_db, monkeypatch):


### PR DESCRIPTION
## 概要
将此前保留在工作区的**并行开发**（图片→SVG 表情包生成能力增强）整理为独立提交。基于最新 `main`（PR #2 合并后）。

## 变更（6 文件）
- **`ark_face_svg.py`**（+336）：增强 ARK 模型响应解析 —— 支持 `thinking` / `max_output_tokens`，flat/grouped 元素坐标归一为 scene 图元，多帧且与 main 兼容的 scene 输出，背景检测与 fallback scene。
- **`expr.html`**（+144）：图片生成结果的 SVG 预览与逐帧浏览（`generatedPreviewSvg`、`imageExpressionResult`、帧浏览器）。
- **`face_preview_2c.js`** / **`theme_2c.css`** / **`base_2c.html`**：预览渲染、样式与资源版本。
- **`test_ark_face_svg.py`**（+179）：新增 3 项单元测试（flat/grouped 坐标归一、多帧 scene 输出）。

## 验证
- `py_compile` 通过；**新增的 3 项纯逻辑单测本地已通过**（`coerce/multiframe/flat/grouped`，无需 ML 依赖）。
- 依赖 `create_app` 的端点级测试需在含 ML 依赖（mediapipe/insightface/cv2/funasr）的 CI/部署环境运行：
  - [ ] `cd service && uv run pytest tests/test_ark_face_svg.py -v`
  - [ ] `cd service && uv run pytest -q`
  - [ ] 手动冒烟：`/expr` 页图片生成 → SVG 预览 → 逐帧浏览。

## 说明
本 PR 内容为工作区中一段停滞约 1.5 小时的未提交工作，为避免丢失而整理提交；作者归属如有需要请在合并前调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)